### PR TITLE
Import error messages and error code added

### DIFF
--- a/CRM.php
+++ b/CRM.php
@@ -342,7 +342,7 @@ $('button.destroy_pager').on('click', function() {
 <div class="dashboard-cont" style="padding-top:110px;">
 	<div class="contacts-title">
 		<h1 class="pull-left">CRM</h1>
-		<a class="pull-right" href="add_client.php" class="add_button">Upload</a>
+		<a class="pull-right" href="uploadForm.php" class="add_button">Upload</a>
 	</div>
 <div class="dashboard-detail">
 

--- a/uploadForm.php
+++ b/uploadForm.php
@@ -13,12 +13,13 @@ if(isset($_SESSION["import_errors"])){
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 
-        <title>DataConsulate</title>
+        <title>Cornerstone Dashboard</title>
 
         <link href="//fonts.googleapis.com/css?family=Lato:300,400|Montserrat" rel="stylesheet" type="text/css">
         <link rel="stylesheet" href="Upload-css/dc.css" type="text/css" />
         <link rel="stylesheet" href="Upload-css/scrollbar.css" type="text/css" />
         <link href="Upload-css/toastr.css" rel="stylesheet"/>
+		<link rel="shortcut icon" type="image/png" href="images/favicon.ico">
 
         <script src="Upload-css/jquery.js"></script>
         <script src="Upload-css/toastr.js"></script>
@@ -100,6 +101,8 @@ var CodeVersion = '3.0.8';
     <input type="button" id="upload" value="Upload" onclick="this.disabled='disabled'"/>
     <hr />
 	<ul style = "border: 2px solid #009966; border-radius: 5px; width: 70%; list-style-type: circle; list-style-position: inside; padding-left: 2%">
+		<li>All input must not exceed max length of 45</li>
+		<li><b>Full Name/Prefix/Suffix Fields:</b> No numerical characters allowed</li>
 		<li><b>Phone/Fax Fields:</b> Must be 10 digit number with no other characters. (e.g 1234567899)</li>
 		<li><b>Extension:</b> Can only be numerical(Do not include Ext. within)</li>
 		<li><b>Call Back Date/Date Added:</b> Must be entered in correct date format as shown - month/day/year (e.g 3/31/2016)
@@ -108,6 +111,8 @@ var CodeVersion = '3.0.8';
 			</ul>
 		</li>
 		<li><b>Email Fields: </b> Must include @gmail, @aol, @yahoo, etc. (e.g James123@gmail)</li>
+		<li><b>Country: </b> Must only be used for a <u>FOREIGN</u> country or left blank. DO NOT enter United States in this field</li>
+		<li><b>Address Line 3: </b> Only used for FOREIGN addresses and a Country field must be included
 	</ul>
 	<fieldset>
 		<div class="widget-corner-upper"></div>
@@ -161,7 +166,7 @@ var CodeVersion = '3.0.8';
 	<?php
 		if(count($errors) > 0){
 			echo "<h4>" . count($errors) . " error(s) found" . "</h4>";
-			echo "<ul style = 'border: 2px solid #ff8080; border-radius: 5px; width: 52%; list-style-type: circle; list-style-position: inside; padding-left: 2%'>";
+			echo "<ul style = 'border: 2px solid #ff8080; border-radius: 5px; width: 68%; list-style-type: circle; list-style-position: inside; padding-left: 2%'>";
 			for($i = 0; $i < count($errors); $i++){
 				echo "<li>" . $errors[$i] . "</li>";
 			}

--- a/uploadForm_database.php
+++ b/uploadForm_database.php
@@ -38,7 +38,7 @@ $sql_statements = array();
 
 for($i = 1; $i < count($data); $i++) //goes through all rows in csv file
 {
-		$sql = 'INSERT INTO sales (rep, quickbooks, prefix, full_name, suffix, title, phone, fax, extension, web_address, business, address_line_1, address_line_2, address_line_3, city, state, zipcode, status, call_back_date, priority, date_added, 
+		$sql = 'INSERT INTO sales (rep, quickbooks, prefix, full_name, suffix, title, phone, fax, extension, web_address, business, country, address_line_1, address_line_2, address_line_3, city, state, zipcode, status, call_back_date, priority, date_added, 
 				mailing_list, pie_day, second_contact, cell_phone, alt_phone, home_phone, email1, email2, vertical1, vertical2, vertical3, source, notes, _2014_pie_day, Non_Profit_Card_08_2013, 
 				Commercial_Card_08_2013, USPS_Post_Office_Mailing_03_2014, Contractor_Small_Business_Select_Mailing_03_2014, Contractor_SB_Select_Mailing_04_2014, USPS_EDDM_Regs_brochure_Mailing_04_2014,
 				USPS_9Y9_EDDM_Marketing_Card, SEPT_2014_3_5Y11_CRST_Marketing_Card, Contractor_Mailing_2016, type) VALUES (';
@@ -46,6 +46,7 @@ for($i = 1; $i < count($data); $i++) //goes through all rows in csv file
 		$sql2 = 'UPDATE sales SET ';
 		$full_name = "";
 		$address_line_1 = "";
+		$foreign_country = FALSE;
 		
 		for($j = 0; $j < count($array_indexes); $j++){ //goes through all corresponding indexes to headers and adds to sql statements for insert and update as specified
 			$input = "";
@@ -54,52 +55,63 @@ for($i = 1; $i < count($data); $i++) //goes through all rows in csv file
 				$input = str_replace('"', '\"', $data[$i][$array_indexes[$j]]);
 				$input = str_replace("'", "\'", $input); 
 			}
-			
-			if($input != "" && preg_match("/[0-9]/i", $input) && $array_names[$j] == "full_name"){
-				array_push($error, "error in row " . ($i + 1) . " column header " . $array_names[$j] . ": Numeric character found");
+			//check if input is greater than 45
+			if(strlen($input) > 45){
+				array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>input size is greater than 45</b> -> " . strlen($input));
+			}
+			//check for numeric characters in full_name, prefix, suffix
+			if(preg_match("/[0-9]+/", $input) && ($array_names[$j] == "full_name" || $array_names[$j] == "prefix" || $array_names[$j] == "suffix")){
+				array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>Numeric character found</b>");
 			}
 			//check if all phone/fax fields are valid inputs
 			if($input != "" && (strlen($input) != 10 || preg_match("/[a-z]/i", $input)) && ($array_names[$j] == "phone" || $array_names[$j] == "fax" || $array_names[$j] == "cell_phone" || $array_names[$j] == "alt_phone" || $array_names[$j] == "home_phone")){
 				if($array_names[$j] == "phone"){
-					array_push($error, "error in row " . ($i + 1) . " column header " . $array_names[$j]);
+					array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>must have 10 digits and no other characters</b>");
 				}
 				else if($array_names[$j] == "fax"){
-					array_push($error, "error in row " . ($i + 1) . " column header " . $array_names[$j]);
+					array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>must have 10 digits and no other characters</b>");
 				}
 				else if($array_names[$j] == "cell_phone"){
-					array_push($error, "error in row " . ($i + 1) . " column header " . $array_names[$j]);
+					array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>must have 10 digits and no other characters</b>");
 				}
 				else if($array_names[$j] == "alt_phone"){
-					array_push($error, "error in row " . ($i + 1) . " column header " . $array_names[$j]);
+					array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>must have 10 digits and no other characters</b>");
 				}
 				else if($array_names[$j] == "home_phone"){
-					array_push($error, "error in row " . ($i + 1) . " column header " . $array_names[$j]);
+					array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>must have 10 digits and no other characters</b>");
 				}	
 			}
 			//check if email input for email1 or email2 is incorrect
 			if($input != "" && strpos($input, '@') === FALSE && ($array_names[$j] == "email1" || $array_names[$j] == "email2")){
-				array_push($error, "error in row " . ($i + 1) . " column header " . $array_names[$j]);
+				array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>email must include @ (e.g. james123@aol)</b>");
 			}
 			//check if extension is numerical
 			if($input != "" && preg_match("/[a-z]/i", $input) && $array_names[$j] == "extension"){
-				array_push($error, "error in row " . ($i + 1) . " column header " . $array_names[$j]);
+				array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>extension must only be numerical (e.g. 123)</b>");
 			}
 			//check if call back date input field is readable or date added is readable
 			if(($array_names[$j] == "call_back_date" || $array_names[$j] == "date_added") && $input != ""){
 				$call_back_date = explode("/", $input);
 				if(count($call_back_date) != 3){ //checks if date has length 3 for day, month, and year
-					array_push($error, "error in row " . ($i + 1) . " column header " . $array_names[$j]);
+					array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>incorrect data format (e.g 1/23/2016)</b>");
 				}
 				else{ //checks if numerical characters are in date
 					for($ii = 0; $ii < count($call_back_date); $ii++){
 						if(!is_numeric($call_back_date[$ii])){
-							array_push($error, "error in row " . ($i + 1) . " column header " . $array_names[$j]);
+							array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>unreadable date. Please check input</b>");
 						}
 					}
 				}
 				$timeConversion = strtotime($input);
 				$input = date("Y-m-d", $timeConversion);
 				
+			}
+			//checks if address line 3 is allowed to be entered or if country field has input
+			if($foreign_country == FALSE && $array_names[$j] == "address_line_3" && $input != ""){
+				array_push($error, "error in row " . ($i + 1) . " column header " . $_POST[$array_names[$j]] . " applied to " . $array_names[$j] . ": <b>address line 3 only used for foreign countries. Can't leave country field blank</b>");
+			}
+			if($array_names[$j] == "country" && $input != ""){
+				$foreign_country = TRUE;
 			}
 			//adds current date for date_added field
 			if($array_names[$j] == "date_added" && $input == ""){


### PR DESCRIPTION
The importer now gives the association of the column header to the database header, ensuring a more specific error message and the ability to pinpoint errors in the CSV file. Also different error checks were created to make sure input doesn't exceed 45 characters, full_name, prefix, and suffix don't contain any numerical characters, and address_line_3 can be used only if country includes a field (not including the United States). New guidelines are shown on the Upload.php page which give specific instructions on the proper inputs allowed in the importing process. As a result, the database has been modified with a country field.